### PR TITLE
feat: expose proxy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,11 @@
-dist: xenial
-sudo: false
 language: node_js
 node_js:
-- 'stable'
-- '10'
 - '8'
 cache: yarn
 stages:
   - lint
   - test
-  - coveralls
 jobs:
   include:
     - stage: lint
       script: yarn lint
-    - stage: coveralls
-      script: yarn coveralls
-env:
-  global:
-    # COVERALLS_REPO_TOKEN=
-      secure: "I8mDH0n2DQHAPvUFEV/ZNmrMNYTJxgywg8+P3yuCAWwQkZeXQi0DWG+6VUpOylaRhL/4kCdZK9gnJD2MfrqvNqVLDUqBK3tTmZVoyqqJEdE0UdEHcPncAPmxWrG98sDjqFN9r4nWeizHvyA1fNRQHRN56Zy+DcQWjgEhHJaYeNA="

--- a/dist/http-proxy-middleware.js
+++ b/dist/http-proxy-middleware.js
@@ -136,6 +136,7 @@ class HttpProxyMiddleware {
         // expose function to upgrade externally
         // middleware.upgrade = wsUpgradeDebounced
         this.middleware.upgrade = this.wsUpgradeDebounced;
+        this.middleware.proxy = this.proxy;
     }
 }
 exports.HttpProxyMiddleware = HttpProxyMiddleware;

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "ws": "^7.0.0"
   },
   "dependencies": {
-    "@gemini-testing/http-proxy": "^1.18.1",
+    "@gemini-testing/http-proxy": "^1.19.0",
     "is-glob": "^4.0.1",
     "lodash": "^4.17.11",
     "micromatch": "^4.0.2"

--- a/src/http-proxy-middleware.ts
+++ b/src/http-proxy-middleware.ts
@@ -44,6 +44,8 @@ export class HttpProxyMiddleware {
     // expose function to upgrade externally
     // middleware.upgrade = wsUpgradeDebounced
     (this.middleware as any).upgrade = this.wsUpgradeDebounced;
+
+    (this.middleware as any).proxy = this.proxy;
   }
 
   // https://github.com/Microsoft/TypeScript/wiki/'this'-in-TypeScript#red-flags-for-this

--- a/yarn.lock
+++ b/yarn.lock
@@ -270,10 +270,10 @@
   dependencies:
     find-up "^2.1.0"
 
-"@gemini-testing/http-proxy@^1.18.0":
-  version "1.18.0"
-  resolved "https://registry.yarnpkg.com/@gemini-testing/http-proxy/-/http-proxy-1.18.0.tgz#5003cfa73b84f7df65a589b00e717953c830d52c"
-  integrity sha512-jORTSg2pC4nTHJ5pJYj6xwPg955Zb+f5J3DvYzOEl6xMlTbBlvH0s5t0E8IP6T0WXR/5vJRl4c0AkYPjueQ1vQ==
+"@gemini-testing/http-proxy@^1.19.0":
+  version "1.19.0"
+  resolved "https://registry.yarnpkg.com/@gemini-testing/http-proxy/-/http-proxy-1.19.0.tgz#f13a2b93d7c23ddcfd64a11250b4a3c51e8cb4f3"
+  integrity sha512-Rt6Pi96uvvh2w7xVh7VZaryJYOjuvwfgQ459qe9YpSqhWWdejuGzHTVAm1Fy9UnuB7bB9NKCATED3pytatkjSA==
   dependencies:
     eventemitter3 "^3.0.0"
     follow-redirects "^1.0.0"


### PR DESCRIPTION
* expose proxy server in order to be available to subscibe on http-proxy events without passing predefined options. It is necessary, because user should be able to redefine them
* update @gemini-testing/http-proxy