### PR TITLE
feat: export http proxy instance

### DIFF
--- a/dist/http-proxy-middleware.js
+++ b/dist/http-proxy-middleware.js
@@ -38,11 +38,11 @@ class HttpProxyMiddleware {
             // subscribe once; don't subscribe on every request...
             // https://github.com/chimurai/http-proxy-middleware/issues/113
             if (!this.wsInitialized) {
-                server.on('upgrade', this.wsUpgradeDebounced);
+                server.on('upgrade', this.upgrade);
                 this.wsInitialized = true;
             }
         };
-        this.handleUpgrade = (req, socket, head) => {
+        this.upgrade = (req, socket, head) => {
             // set to initialized when used externally
             this.wsInitialized = true;
             if (this.shouldProxy(this.config.context, req)) {
@@ -120,8 +120,6 @@ class HttpProxyMiddleware {
             const errReference = 'https://nodejs.org/api/errors.html#errors_common_system_errors'; // link to Node Common Systems Errors page
             this.logger.error(errorMessage, req.url, hostname, target, err.code || err, errReference);
         };
-        // https://github.com/chimurai/http-proxy-middleware/issues/57
-        this.wsUpgradeDebounced = _.debounce(this.handleUpgrade);
         this.config = config_factory_1.createConfig(context, opts);
         this.proxyOptions = this.config.options;
         // create proxy
@@ -132,7 +130,6 @@ class HttpProxyMiddleware {
         handlers.init(this.proxy, this.proxyOptions);
         // log errors for debug purpose
         this.proxy.on('error', this.logError);
-        this.upgrade = this.wsUpgradeDebounced;
     }
 }
 exports.HttpProxyMiddleware = HttpProxyMiddleware;

--- a/dist/http-proxy-middleware.js
+++ b/dist/http-proxy-middleware.js
@@ -132,11 +132,7 @@ class HttpProxyMiddleware {
         handlers.init(this.proxy, this.proxyOptions);
         // log errors for debug purpose
         this.proxy.on('error', this.logError);
-        // https://github.com/chimurai/http-proxy-middleware/issues/19
-        // expose function to upgrade externally
-        // middleware.upgrade = wsUpgradeDebounced
-        this.middleware.upgrade = this.wsUpgradeDebounced;
-        this.middleware.proxy = this.proxy;
+        this.upgrade = this.wsUpgradeDebounced;
     }
 }
 exports.HttpProxyMiddleware = HttpProxyMiddleware;

--- a/dist/index.js
+++ b/dist/index.js
@@ -1,7 +1,6 @@
 "use strict";
 const http_proxy_middleware_1 = require("./http-proxy-middleware");
 function proxy(context, opts) {
-    const { middleware } = new http_proxy_middleware_1.HttpProxyMiddleware(context, opts);
-    return middleware;
+    return new http_proxy_middleware_1.HttpProxyMiddleware(context, opts);
 }
 module.exports = proxy;

--- a/src/http-proxy-middleware.ts
+++ b/src/http-proxy-middleware.ts
@@ -9,17 +9,13 @@ import * as Router from './router';
 
 export class HttpProxyMiddleware {
   private logger = getInstance();
-  private wsUpgradeDebounced;
   private config;
   private wsInitialized = false;
   private proxyOptions;
   private proxy;
-  private upgrade;
   private pathRewriter;
 
   constructor(context, opts) {
-    // https://github.com/chimurai/http-proxy-middleware/issues/57
-    this.wsUpgradeDebounced = _.debounce(this.handleUpgrade);
     this.config = createConfig(context, opts);
     this.proxyOptions = this.config.options;
 
@@ -40,8 +36,6 @@ export class HttpProxyMiddleware {
 
     // log errors for debug purpose
     this.proxy.on('error', this.logError);
-
-    this.upgrade = this.wsUpgradeDebounced;
   }
 
   // https://github.com/Microsoft/TypeScript/wiki/'this'-in-TypeScript#red-flags-for-this
@@ -63,12 +57,12 @@ export class HttpProxyMiddleware {
     // subscribe once; don't subscribe on every request...
     // https://github.com/chimurai/http-proxy-middleware/issues/113
     if (!this.wsInitialized) {
-      server.on('upgrade', this.wsUpgradeDebounced);
+      server.on('upgrade', this.upgrade);
       this.wsInitialized = true;
     }
   };
 
-  private handleUpgrade = (req, socket, head) => {
+  private upgrade = (req, socket, head) => {
     // set to initialized when used externally
     this.wsInitialized = true;
 

--- a/src/http-proxy-middleware.ts
+++ b/src/http-proxy-middleware.ts
@@ -14,6 +14,7 @@ export class HttpProxyMiddleware {
   private wsInitialized = false;
   private proxyOptions;
   private proxy;
+  private upgrade;
   private pathRewriter;
 
   constructor(context, opts) {
@@ -40,12 +41,7 @@ export class HttpProxyMiddleware {
     // log errors for debug purpose
     this.proxy.on('error', this.logError);
 
-    // https://github.com/chimurai/http-proxy-middleware/issues/19
-    // expose function to upgrade externally
-    // middleware.upgrade = wsUpgradeDebounced
-    (this.middleware as any).upgrade = this.wsUpgradeDebounced;
-
-    (this.middleware as any).proxy = this.proxy;
+    this.upgrade = this.wsUpgradeDebounced;
   }
 
   // https://github.com/Microsoft/TypeScript/wiki/'this'-in-TypeScript#red-flags-for-this

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,7 @@
 import { HttpProxyMiddleware } from './http-proxy-middleware';
 
 function proxy(context, opts) {
-  const { middleware } = new HttpProxyMiddleware(context, opts);
-  return middleware;
+  return new HttpProxyMiddleware(context, opts);
 }
 
 export = proxy;


### PR DESCRIPTION
* export http proxy instance for more precise customization
* set `upgrade` as http proxy field in order to handle upgrade connection as `proxyInstance.upgrade` instead `proxyInstance.middleware.upgrade`
* remove `_.debounce` of `upgrade` ws connection in order to be able to catch the error thrown inside `upgrade`